### PR TITLE
Added a downloadAttributes trigger to the waitForCopyToComplete function

### DIFF
--- a/src/BlobBasics.java
+++ b/src/BlobBasics.java
@@ -528,6 +528,7 @@ public class BlobBasics {
         CopyStatus copyStatus = CopyStatus.PENDING;
         while (copyStatus == CopyStatus.PENDING) {
             Thread.sleep(1000);
+            blob.downloadAttributes();
             copyStatus = blob.getCopyState().getStatus();
         }
     }


### PR DESCRIPTION
I noticed that the copy status won't be updated without the downloadAttributes call. We noticed this when copying a blob to another storage account.