### PR TITLE
Fixed mainClass and updated azure-storage api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-storage</artifactId>
-      <version>4.2.0</version>
+      <version>8.0.0</version>
     </dependency>
   </dependencies>
   <build>
@@ -26,7 +26,7 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.4.0</version>
         <configuration>
-             <mainClass>BlobBasics</mainClass>
+             <mainClass>Main</mainClass>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Updated the below in pom.xml

- Fixed mainClass to use correct 'Main' class instead of 'BlobBasics'
- Updated version of azure-storage api latest version to 8.0.0 (Jun 2018), as of now points to 4.2.0 (released in Apr 2016) 